### PR TITLE
SFAT-241 - backups / SFAT-237 - encryption / NFT

### DIFF
--- a/terraform/environments/nft/main.tf
+++ b/terraform/environments/nft/main.tf
@@ -36,4 +36,5 @@ module "deploy" {
   skip_final_snapshot             = false
   enabled_cloudwatch_logs_exports = ["postgresql"]
   backup_retention_period         = 35
+  agreements_cluster_instances    = 3
 }

--- a/terraform/environments/nft/main.tf
+++ b/terraform/environments/nft/main.tf
@@ -35,4 +35,5 @@ module "deploy" {
   deletion_protection             = false
   skip_final_snapshot             = false
   enabled_cloudwatch_logs_exports = ["postgresql"]
+  backup_retention_period         = 35
 }

--- a/terraform/environments/nft/main.tf
+++ b/terraform/environments/nft/main.tf
@@ -36,5 +36,5 @@ module "deploy" {
   skip_final_snapshot             = false
   enabled_cloudwatch_logs_exports = ["postgresql"]
   backup_retention_period         = 35
-  agreements_cluster_instances    = 3
+  agreements_cluster_instances    = length(local.availability_zones)
 }

--- a/terraform/environments/sbx1/main.tf
+++ b/terraform/environments/sbx1/main.tf
@@ -35,4 +35,5 @@ module "deploy" {
   deletion_protection             = false
   skip_final_snapshot             = false
   enabled_cloudwatch_logs_exports = ["postgresql"]
+  agreements_cluster_instances    = 3
 }

--- a/terraform/modules/agreements/main.tf
+++ b/terraform/modules/agreements/main.tf
@@ -64,6 +64,8 @@ resource "aws_rds_cluster" "default" {
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
   skip_final_snapshot             = var.skip_final_snapshot
   final_snapshot_identifier       = "final-snaphot-agreements-${uuid()}"
+  backup_retention_period         = var.backup_retention_period
+  preferred_backup_window         = "00:57-01:27"
 
   lifecycle {
     ignore_changes = [

--- a/terraform/modules/agreements/variables.tf
+++ b/terraform/modules/agreements/variables.tf
@@ -28,5 +28,9 @@ variable "enabled_cloudwatch_logs_exports" {
 }
 
 variable "backup_retention_period" {
-  type    = number
+  type = number
+}
+
+variable "cluster_instances" {
+  type = number
 }

--- a/terraform/modules/agreements/variables.tf
+++ b/terraform/modules/agreements/variables.tf
@@ -26,3 +26,7 @@ variable "skip_final_snapshot" {
 variable "enabled_cloudwatch_logs_exports" {
   type = list(string)
 }
+
+variable "backup_retention_period" {
+  type    = number
+}

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -33,4 +33,5 @@ module "agreements" {
   deletion_protection             = var.deletion_protection
   skip_final_snapshot             = var.skip_final_snapshot
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
+  backup_retention_period         = var.backup_retention_period
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -34,4 +34,5 @@ module "agreements" {
   skip_final_snapshot             = var.skip_final_snapshot
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
   backup_retention_period         = var.backup_retention_period
+  cluster_instances               = var.agreements_cluster_instances
 }

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -27,3 +27,8 @@ variable "backup_retention_period" {
   type    = number
   default = 1
 }
+
+variable "agreements_cluster_instances" {
+  type    = number
+  default = 1
+}

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -22,3 +22,8 @@ variable "skip_final_snapshot" {
 variable "enabled_cloudwatch_logs_exports" {
   type = list(string)
 }
+
+variable "backup_retention_period" {
+  type    = number
+  default = 1
+}


### PR DESCRIPTION
SFAT-241 - Backup window & retention period settings based on email (in JIRA) and current settings on NFT - setup manually by TechOps at Som's request

SFAT-237 - Encryption

Updated connection string to use cluster rather than instance specific. Also updated Agreements to use read-only endpoint, as it does not require write access, and read endpoint should be more scalable.

NFT - increased number of instances to 3. This should create an instance in each AZ. I have tested deleting the current instance - and observed it is a faultless rollover of connections to another instance. In addition - if you delete the Writer instance, one of the reader instances is promoted to a new writer.