### PR TITLE
SINF-406 - set publicly_accessible to false

### DIFF
--- a/terraform/modules/agreements/main.tf
+++ b/terraform/modules/agreements/main.tf
@@ -111,7 +111,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   instance_class       = "db.t3.medium"
   engine               = "aurora-postgresql"
   apply_immediately    = true
-  publicly_accessible  = true
+  publicly_accessible  = false
   db_subnet_group_name = aws_db_subnet_group.agreements.name
 }
 


### PR DESCRIPTION
Following observations from Zac - changed `publicly_accessible` from `true` to `false` (db was not actually available publicly, but better to have this flag set to false anyway).

Tested on SBX1 (on bat/develop branch as had that deployed - but to all intents and purposes that is the same as develop). Updated DB and reset connections (by killing ECS tasks and letting new ones be generated) - and UI and Postman continued to function 