### PR TITLE
SINF-406 remove explicit postgres version setting

### DIFF
--- a/terraform/modules/agreements/main.tf
+++ b/terraform/modules/agreements/main.tf
@@ -81,7 +81,6 @@ resource "aws_rds_cluster" "default" {
   master_username                 = data.aws_ssm_parameter.master_username.value
   master_password                 = data.aws_ssm_parameter.master_password.value
   engine                          = "aurora-postgresql"
-  engine_version                  = "11.8"
   apply_immediately               = true
   vpc_security_group_ids          = ["${aws_security_group.allow_postgres_external.id}"]
   deletion_protection             = var.deletion_protection


### PR DESCRIPTION
Applying latest change to TST failed as version is specified as 11.8 in Terraform, but AWS had auto applied a minor patch to 11.9 now.

Rather than updating to 11.9 explicitly, not specifying should mean it uses the default version (so hopefully remove issue if it happens again).